### PR TITLE
Make the checksum field optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Supported sentences (alphabetically ordered):
 
 [`Nmea::parse()`]: https://docs.rs/nmea/latest/nmea/struct.Nmea.html#method.parse
 
+### Checksum calculation
+
+The checksum is ignored if the sentence does not contain it, otherwise is validated.
+
 ## How to contribute
 
 We have an ongoing effort to support as many sentences from `NMEA 0183` as possible,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -41,7 +41,7 @@ pub struct NmeaSentence<'a> {
     pub talker_id: &'a str,
     pub message_id: SentenceType,
     pub data: &'a str,
-    pub checksum: u8,
+    pub checksum: Option<u8>,
 }
 
 impl NmeaSentence<'_> {
@@ -81,6 +81,9 @@ fn do_parse_nmea_sentence(i: &str) -> IResult<&str, NmeaSentence> {
     let (i, _) = char(',')(i)?;
     let (i, data) = take_until("*")(i)?;
     let (i, checksum) = parse_checksum(i)?;
+
+    // TODO rework it!
+    let checksum = Some(checksum);
 
     Ok((
         i,
@@ -203,278 +206,283 @@ pub fn parse_str(sentence_input: &str) -> Result<ParseResult, Error> {
     }
 
     let nmea_sentence = parse_nmea_sentence(sentence_input)?;
-    let calculated_checksum = nmea_sentence.calc_checksum();
 
-    if nmea_sentence.checksum == calculated_checksum {
-        // Ordered alphabetically
-        match nmea_sentence.message_id {
-            SentenceType::AAM => {
-                cfg_if! {
-                    if #[cfg(feature = "AAM")] {
-                        parse_aam(nmea_sentence).map(ParseResult::AAM)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::ALM => {
-                cfg_if! {
-                    if #[cfg(feature = "ALM")] {
-                        parse_alm(nmea_sentence).map(ParseResult::ALM)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::APA => {
-                cfg_if! {
-                    if #[cfg(feature = "APA")] {
-                        parse_apa(nmea_sentence).map(ParseResult::APA)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::BOD => {
-                cfg_if! {
-                    if #[cfg(feature = "BOD")] {
-                        parse_bod(nmea_sentence).map(ParseResult::BOD)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::BWC => {
-                cfg_if! {
-                    if #[cfg(feature = "BWC")] {
-                        parse_bwc(nmea_sentence).map(ParseResult::BWC)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::BWW => {
-                cfg_if! {
-                    if #[cfg(feature = "BWW")] {
-                        parse_bww(nmea_sentence).map(ParseResult::BWW)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::DBK => {
-                cfg_if! {
-                    if #[cfg(feature = "DBK")] {
-                        parse_dbk(nmea_sentence).map(Into::into)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GBS => {
-                cfg_if! {
-                    if #[cfg(feature = "GBS")] {
-                        parse_gbs(nmea_sentence).map(ParseResult::GBS)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GGA => {
-                cfg_if! {
-                    if #[cfg(feature = "GGA")] {
-                        parse_gga(nmea_sentence).map(ParseResult::GGA)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GLL => {
-                cfg_if! {
-                    if #[cfg(feature = "GLL")] {
-                        parse_gll(nmea_sentence).map(ParseResult::GLL)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GNS => {
-                cfg_if! {
-                    if #[cfg(feature = "GNS")] {
-                        parse_gns(nmea_sentence).map(ParseResult::GNS)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GSA => {
-                cfg_if! {
-                    if #[cfg(feature = "GSA")] {
-                        parse_gsa(nmea_sentence).map(ParseResult::GSA)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GST => {
-                cfg_if! {
-                    if #[cfg(feature = "GST")] {
-                        parse_gst(nmea_sentence).map(ParseResult::GST)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::GSV => {
-                cfg_if! {
-                    if #[cfg(feature = "GSV")] {
-                        parse_gsv(nmea_sentence).map(ParseResult::GSV)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::HDT => {
-                cfg_if! {
-                    if #[cfg(feature = "HDT")] {
-                        parse_hdt(nmea_sentence).map(ParseResult::HDT)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::MDA => {
-                cfg_if! {
-                    if #[cfg(feature = "MDA")] {
-                        parse_mda(nmea_sentence).map(ParseResult::MDA)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::MTW => {
-                cfg_if! {
-                    if #[cfg(feature = "MTW")] {
-                        parse_mtw(nmea_sentence).map(ParseResult::MTW)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::MWV => {
-                cfg_if! {
-                    if #[cfg(feature = "MWV")] {
-                        parse_mwv(nmea_sentence).map(ParseResult::MWV)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::RMC => {
-                cfg_if! {
-                    if #[cfg(feature = "RMC")] {
-                        parse_rmc(nmea_sentence).map(ParseResult::RMC)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::RMZ => {
-                cfg_if! {
-                    if #[cfg(feature = "RMZ")] {
-                        parse_pgrmz(nmea_sentence).map(ParseResult::PGRMZ)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::TTM => {
-                cfg_if! {
-                    if #[cfg(feature = "TTM")] {
-                        parse_ttm(nmea_sentence).map(ParseResult::TTM)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::TXT => {
-                cfg_if! {
-                    if #[cfg(feature = "TXT")] {
-                        parse_txt(nmea_sentence).map(ParseResult::TXT)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::VHW => {
-                cfg_if! {
-                    if #[cfg(feature = "VHW")] {
-                        parse_vhw(nmea_sentence).map(ParseResult::VHW)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::VTG => {
-                cfg_if! {
-                    if #[cfg(feature = "VTG")] {
-                        parse_vtg(nmea_sentence).map(ParseResult::VTG)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::WNC => {
-                cfg_if! {
-                    if #[cfg(feature = "WNC")] {
-                        parse_wnc(nmea_sentence).map(ParseResult::WNC)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::ZDA => {
-                cfg_if! {
-                    if #[cfg(feature = "ZDA")] {
-                        parse_zda(nmea_sentence).map(ParseResult::ZDA)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::ZFO => {
-                cfg_if! {
-                    if #[cfg(feature = "ZFO")] {
-                        parse_zfo(nmea_sentence).map(ParseResult::ZFO)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::ZTG => {
-                cfg_if! {
-                    if #[cfg(feature = "ZTG")] {
-                        parse_ztg(nmea_sentence).map(ParseResult::ZTG)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            SentenceType::DPT => {
-                cfg_if! {
-                    if #[cfg(feature = "DPT")] {
-                        parse_dpt(nmea_sentence).map(ParseResult::DPT)
-                    } else {
-                        return Err(Error::DisabledSentence);
-                    }
-                }
-            }
-            sentence_type => Ok(ParseResult::Unsupported(sentence_type)),
+    if let Some(checksum) = nmea_sentence.checksum {
+        let calculated_checksum = nmea_sentence.calc_checksum();
+        if checksum != calculated_checksum {
+            return Err(Error::ChecksumMismatch {
+                calculated: calculated_checksum,
+                found: checksum,
+            });
         }
-    } else {
-        Err(Error::ChecksumMismatch {
-            calculated: calculated_checksum,
-            found: nmea_sentence.checksum,
-        })
+    }
+
+    convert_sentence_into_parse_result(nmea_sentence)
+}
+
+fn convert_sentence_into_parse_result(nmea_sentence: NmeaSentence) -> Result<ParseResult, Error> {
+    match nmea_sentence.message_id {
+        SentenceType::AAM => {
+            cfg_if! {
+                if #[cfg(feature = "AAM")] {
+                    parse_aam(nmea_sentence).map(ParseResult::AAM)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::ALM => {
+            cfg_if! {
+                if #[cfg(feature = "ALM")] {
+                    parse_alm(nmea_sentence).map(ParseResult::ALM)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::APA => {
+            cfg_if! {
+                if #[cfg(feature = "APA")] {
+                    parse_apa(nmea_sentence).map(ParseResult::APA)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::BOD => {
+            cfg_if! {
+                if #[cfg(feature = "BOD")] {
+                    parse_bod(nmea_sentence).map(ParseResult::BOD)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::BWC => {
+            cfg_if! {
+                if #[cfg(feature = "BWC")] {
+                    parse_bwc(nmea_sentence).map(ParseResult::BWC)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::BWW => {
+            cfg_if! {
+                if #[cfg(feature = "BWW")] {
+                    parse_bww(nmea_sentence).map(ParseResult::BWW)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::DBK => {
+            cfg_if! {
+                if #[cfg(feature = "DBK")] {
+                    parse_dbk(nmea_sentence).map(Into::into)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GBS => {
+            cfg_if! {
+                if #[cfg(feature = "GBS")] {
+                    parse_gbs(nmea_sentence).map(ParseResult::GBS)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GGA => {
+            cfg_if! {
+                if #[cfg(feature = "GGA")] {
+                    parse_gga(nmea_sentence).map(ParseResult::GGA)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GLL => {
+            cfg_if! {
+                if #[cfg(feature = "GLL")] {
+                    parse_gll(nmea_sentence).map(ParseResult::GLL)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GNS => {
+            cfg_if! {
+                if #[cfg(feature = "GNS")] {
+                    parse_gns(nmea_sentence).map(ParseResult::GNS)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GSA => {
+            cfg_if! {
+                if #[cfg(feature = "GSA")] {
+                    parse_gsa(nmea_sentence).map(ParseResult::GSA)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GST => {
+            cfg_if! {
+                if #[cfg(feature = "GST")] {
+                    parse_gst(nmea_sentence).map(ParseResult::GST)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::GSV => {
+            cfg_if! {
+                if #[cfg(feature = "GSV")] {
+                    parse_gsv(nmea_sentence).map(ParseResult::GSV)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::HDT => {
+            cfg_if! {
+                if #[cfg(feature = "HDT")] {
+                    parse_hdt(nmea_sentence).map(ParseResult::HDT)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::MDA => {
+            cfg_if! {
+                if #[cfg(feature = "MDA")] {
+                    parse_mda(nmea_sentence).map(ParseResult::MDA)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::MTW => {
+            cfg_if! {
+                if #[cfg(feature = "MTW")] {
+                    parse_mtw(nmea_sentence).map(ParseResult::MTW)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::MWV => {
+            cfg_if! {
+                if #[cfg(feature = "MWV")] {
+                    parse_mwv(nmea_sentence).map(ParseResult::MWV)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::RMC => {
+            cfg_if! {
+                if #[cfg(feature = "RMC")] {
+                    parse_rmc(nmea_sentence).map(ParseResult::RMC)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::RMZ => {
+            cfg_if! {
+                if #[cfg(feature = "RMZ")] {
+                    parse_pgrmz(nmea_sentence).map(ParseResult::PGRMZ)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::TTM => {
+            cfg_if! {
+                if #[cfg(feature = "TTM")] {
+                    parse_ttm(nmea_sentence).map(ParseResult::TTM)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::TXT => {
+            cfg_if! {
+                if #[cfg(feature = "TXT")] {
+                    parse_txt(nmea_sentence).map(ParseResult::TXT)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::VHW => {
+            cfg_if! {
+                if #[cfg(feature = "VHW")] {
+                    parse_vhw(nmea_sentence).map(ParseResult::VHW)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::VTG => {
+            cfg_if! {
+                if #[cfg(feature = "VTG")] {
+                    parse_vtg(nmea_sentence).map(ParseResult::VTG)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::WNC => {
+            cfg_if! {
+                if #[cfg(feature = "WNC")] {
+                    parse_wnc(nmea_sentence).map(ParseResult::WNC)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::ZDA => {
+            cfg_if! {
+                if #[cfg(feature = "ZDA")] {
+                    parse_zda(nmea_sentence).map(ParseResult::ZDA)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::ZFO => {
+            cfg_if! {
+                if #[cfg(feature = "ZFO")] {
+                    parse_zfo(nmea_sentence).map(ParseResult::ZFO)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::ZTG => {
+            cfg_if! {
+                if #[cfg(feature = "ZTG")] {
+                    parse_ztg(nmea_sentence).map(ParseResult::ZTG)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        SentenceType::DPT => {
+            cfg_if! {
+                if #[cfg(feature = "DPT")] {
+                    parse_dpt(nmea_sentence).map(ParseResult::DPT)
+                } else {
+                    return Err(Error::DisabledSentence);
+                }
+            }
+        }
+        sentence_type => Ok(ParseResult::Unsupported(sentence_type)),
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -83,19 +83,22 @@ fn do_parse_nmea_sentence(i: &str) -> core::result::Result<NmeaSentence, Error<'
     let (i, message_id) = parse_sentence_type(i)?;
     let (i, _) = char(',')(i)?;
     let (i, data) = take_while_no_star(i)?;
-    let checksum = if i.len() > 0 {
-        let (_i, checksum) = parse_checksum(i)?;
-        Some(checksum)
-    } else {
-        None
-    };
 
-    Ok(NmeaSentence {
+    let mut sentence = NmeaSentence {
         talker_id,
         message_id,
         data,
-        checksum,
-    })
+        checksum: None,
+    };
+
+    if i.len() > 0 {
+        let (_i, checksum) = parse_checksum(i)?;
+        sentence.checksum = Some(checksum);
+    } else {
+        sentence.checksum = Some(sentence.calc_checksum());
+    };
+
+    Ok(sentence)
 }
 
 pub fn parse_nmea_sentence(sentence: &str) -> core::result::Result<NmeaSentence, Error<'_>> {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -78,7 +78,7 @@ fn take_while_no_star(s: &str) -> IResult<&str, &str> {
     take_while(|c| c != '*')(s)
 }
 
-fn do_parse_nmea_sentence(i: &str) -> IResult<&str, NmeaSentence> {
+fn do_parse_nmea_sentence(i: &str) -> core::result::Result<NmeaSentence, Error<'_>> {
     let (i, talker_id) = preceded(char('$'), take(2usize))(i)?;
     let (i, message_id) = parse_sentence_type(i)?;
     let (i, _) = char(',')(i)?;
@@ -90,22 +90,19 @@ fn do_parse_nmea_sentence(i: &str) -> IResult<&str, NmeaSentence> {
         None
     };
 
-    Ok((
-        i,
-        NmeaSentence {
-            talker_id,
-            message_id,
-            data,
-            checksum,
-        },
-    ))
+    Ok(NmeaSentence {
+        talker_id,
+        message_id,
+        data,
+        checksum,
+    })
 }
 
 pub fn parse_nmea_sentence(sentence: &str) -> core::result::Result<NmeaSentence, Error<'_>> {
     if sentence.len() > SENTENCE_MAX_LEN {
         Err(Error::SentenceLength(sentence.len()))
     } else {
-        Ok(do_parse_nmea_sentence(sentence)?.1)
+        do_parse_nmea_sentence(sentence)
     }
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,16 +1,15 @@
 use core::str;
 
 use nom::{
-    bytes::complete::{take, take_until},
+    bytes::complete::{take, take_while},
     character::complete::char,
     combinator::map_res,
     sequence::preceded,
     IResult,
 };
 
-use cfg_if::cfg_if;
-
 use crate::{sentences::*, Error, SentenceType};
+use cfg_if::cfg_if;
 
 /// The maximum message length parsable by the crate.
 ///
@@ -75,15 +74,21 @@ fn parse_sentence_type(i: &str) -> IResult<&str, SentenceType> {
     })(i)
 }
 
+fn take_while_no_star(s: &str) -> IResult<&str, &str> {
+    take_while(|c| c != '*')(s)
+}
+
 fn do_parse_nmea_sentence(i: &str) -> IResult<&str, NmeaSentence> {
     let (i, talker_id) = preceded(char('$'), take(2usize))(i)?;
     let (i, message_id) = parse_sentence_type(i)?;
     let (i, _) = char(',')(i)?;
-    let (i, data) = take_until("*")(i)?;
-    let (i, checksum) = parse_checksum(i)?;
-
-    // TODO rework it!
-    let checksum = Some(checksum);
+    let (i, data) = take_while_no_star(i)?;
+    let checksum = if i.len() > 0 {
+        let (_i, checksum) = parse_checksum(i)?;
+        Some(checksum)
+    } else {
+        None
+    };
 
     Ok((
         i,
@@ -484,5 +489,31 @@ fn convert_sentence_into_parse_result(nmea_sentence: NmeaSentence) -> Result<Par
             }
         }
         sentence_type => Ok(ParseResult::Unsupported(sentence_type)),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::parse_str;
+
+    #[test]
+    fn parse_str_feed_with_correct_checksum() {
+        let input = "$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*76";
+        let result = parse_str(input);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn parse_str_feed_with_incorrect_checksum() {
+        let input = "$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,*88";
+        let result = parse_str(input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_str_feed_with_missing_checksum() {
+        let input = "$GPGGA,092750.000,5321.6802,N,00630.3372,W,1,8,1.03,61.7,M,55.2,M,,";
+        let result = parse_str(input);
+        assert!(result.is_ok());
     }
 }

--- a/src/sentences/aam.rs
+++ b/src/sentences/aam.rs
@@ -103,7 +103,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::AAM,
             data: "A,V,0.10,N,WPTNME",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
 
@@ -121,7 +121,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::AAM,
             data: "G,V,0.10,N,WPTNME",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
     }
@@ -133,7 +133,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::AAM,
             data: "V,X,0.10,N,WPTNME",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
     }
@@ -145,7 +145,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::AAM,
             data: "V,A,0.10,P,WPTNME",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
     }
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn parse_aam_full_sentence() {
         let sentence = parse_nmea_sentence("$GPAAM,A,A,0.10,N,WPTNME*32").unwrap();
-        assert_eq!(sentence.checksum, 0x32);
+        assert_eq!(sentence.checksum.unwrap(), 0x32);
         assert_eq!(sentence.calc_checksum(), 0x32);
 
         let data = parse_aam(sentence).unwrap();
@@ -170,7 +170,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::ABK,
             data: "A,V,0.10,N,WPTNME",
-            checksum: 0x43,
+            checksum: Some(0x43),
         })
         .unwrap_err();
 

--- a/src/sentences/alm.rs
+++ b/src/sentences/alm.rs
@@ -189,8 +189,8 @@ mod tests {
             "$GPALM,31,1,02,1617,00,50F6,0F,FD98,FD39,A10CF3,81389B,423632,BD913C,148,001*3C";
 
         let sentence = parse_nmea_sentence(sentence_string).unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x3C);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x3C);
 
         let data = parse_alm(sentence).unwrap();
         assert_eq!(

--- a/src/sentences/apa.rs
+++ b/src/sentences/apa.rs
@@ -191,7 +191,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::APA,
             data: "A,A,0.10,R,N,V,V,011,M,DEST,011,M*42",
-            checksum: 0x3E,
+            checksum: Some(0x3E),
         })
         .unwrap();
 
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn parse_apa_full_sentence() {
         let sentence = parse_nmea_sentence("$GPAPA,A,A,0.10,R,N,V,V,011,M,DEST,011,M*42").unwrap();
-        assert_eq!(sentence.checksum, 0x42);
+        assert_eq!(sentence.checksum.unwrap(), 0x42);
         assert_eq!(sentence.calc_checksum(), 0x42);
 
         let data = parse_apa(sentence).unwrap();
@@ -233,7 +233,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::APA,
             data: "G,A,0.10,R,N,V,V,011,M,DEST,011,M*4",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
     }
@@ -245,7 +245,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::APA,
             data: "A,A,0.10,R,N,V,V,011,X,DEST,011,M*4",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
     }
@@ -257,7 +257,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::APA,
             data: "A,A,0.10,R,C,V,V,011,M,DEST,011,M*4",
-            checksum: 0x0,
+            checksum: Some(0x0),
         })
         .unwrap();
     }
@@ -268,7 +268,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::ABK,
             data: "A,A,0.10,R,N,V,V,011,M,DEST,011,M*42",
-            checksum: 0x43,
+            checksum: Some(0x43),
         })
         .unwrap_err();
 

--- a/src/sentences/bod.rs
+++ b/src/sentences/bod.rs
@@ -98,8 +98,8 @@ mod tests {
     #[test]
     fn parse_bod_with_route_active_example_full() {
         let sentence = parse_nmea_sentence("$GPBOD,097.0,T,103.2,M,POINTB,POINTA*4A").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x4A);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x4A);
 
         let data = parse_bod(sentence).unwrap();
         assert_relative_eq!(data.bearing_true.unwrap(), 97.0);
@@ -111,8 +111,8 @@ mod tests {
     #[test]
     fn parse_bod_with_route_active_missing_destination_waypoint_example_full() {
         let sentence = parse_nmea_sentence("$GPBOD,097.0,T,103.2,M,,POINTA*44").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x44);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x44);
 
         let data = parse_bod(sentence).unwrap();
         assert_relative_eq!(data.bearing_true.unwrap(), 97.0);
@@ -126,8 +126,8 @@ mod tests {
         // this is equivalent to the "no route active" test, except here there is a comma with an empty field
         // before the checksum. This is just to make sure parsing is resilient to missing data.
         let sentence = parse_nmea_sentence("$GPBOD,097.0,T,103.2,M,POINTB,*47").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x47);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x47);
 
         let data = parse_bod(sentence).unwrap();
         assert_relative_eq!(data.bearing_true.unwrap(), 97.0);
@@ -139,8 +139,8 @@ mod tests {
     #[test]
     fn parse_bod_no_route_active_example_full() {
         let sentence = parse_nmea_sentence("$GPBOD,099.3,T,105.6,M,POINTB*64").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x64);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x64);
         let data = parse_bod(sentence).unwrap();
 
         assert_relative_eq!(data.bearing_true.unwrap(), 99.3);
@@ -152,8 +152,8 @@ mod tests {
     #[test]
     fn parse_bod_no_route_active_no_bearing_example_full() {
         let sentence = parse_nmea_sentence("$GPBOD,,T,105.6,M,POINTB*49").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x49);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x49);
         let data = parse_bod(sentence).unwrap();
 
         assert!(data.bearing_true.is_none());

--- a/src/sentences/bwc.rs
+++ b/src/sentences/bwc.rs
@@ -127,8 +127,8 @@ mod tests {
             "$GPBWC,220516,5130.02,N,00046.34,W,213.8,T,218.0,M,0004.6,N,EGLM*21",
         )
         .unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x21);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x21);
 
         let data = parse_bwc(sentence).unwrap();
 
@@ -147,8 +147,8 @@ mod tests {
     #[test]
     fn test_parse_bwc_with_optional_fields() {
         let sentence = parse_nmea_sentence("$GPBWC,081837,,,,,,T,,M,,N,*13").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x13);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x13);
 
         let data = parse_bwc(sentence).unwrap();
 

--- a/src/sentences/bww.rs
+++ b/src/sentences/bww.rs
@@ -103,8 +103,8 @@ mod tests {
     #[test]
     fn test_parse_bww_full() {
         let sentence = parse_nmea_sentence("$GPBWW,213.8,T,218.0,M,TOWPT,FROMWPT*42").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x42);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x42);
 
         let data = parse_bww(sentence).unwrap();
 
@@ -117,8 +117,8 @@ mod tests {
     #[test]
     fn test_parse_bww_with_optional_fields() {
         let sentence = parse_nmea_sentence("$GPBWW,,T,,M,,*4C").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x4C);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x4C);
 
         let data = parse_bww(sentence).unwrap();
 

--- a/src/sentences/dbk.rs
+++ b/src/sentences/dbk.rs
@@ -99,8 +99,8 @@ mod tests {
     #[test]
     fn test_parse_dbk() {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,M,0221.6,F*2E").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x2E);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x2E);
         let dbk_data = parse_dbk(s).unwrap();
         assert_eq!(Some(1330.5), dbk_data.depth_feet);
         assert_eq!(Some(405.5), dbk_data.depth_meters);
@@ -109,56 +109,56 @@ mod tests {
     #[test]
     fn test_parse_dbk_invalid_depth_feet_value() {
         let s = parse_nmea_sentence("$SDDBK,1FF0.5,f,0405.5,M,0221.6,F*2E").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x2E);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x2E);
         assert!(parse_dbk(s).is_err());
     }
 
     #[test]
     fn test_parse_dbk_invalid_depth_feet_unit() {
         let s = parse_nmea_sentence("$SDDBK,1330.5,X,0405.5,M,0221.6,F*10").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x10);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x10);
         assert!(parse_dbk(s).is_err());
     }
 
     #[test]
     fn test_parse_dbk_invalid_depth_meters_value() {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,04F5.5,M,0221.6,F*58").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x58);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x58);
         assert!(parse_dbk(s).is_err());
     }
 
     #[test]
     fn test_parse_dbk_invalid_depth_meters_unit() {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,X,0221.6,F*3B").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x3B);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x3B);
         assert!(parse_dbk(s).is_err());
     }
 
     #[test]
     fn test_parse_dbk_invalid_depth_fathoms_value() {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,M,02F1.6,F*5A").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x5A);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x5A);
         assert!(parse_dbk(s).is_err());
     }
 
     #[test]
     fn test_parse_dbk_invalid_depth_fathoms_unit() {
         let s = parse_nmea_sentence("$SDDBK,1330.5,f,0405.5,M,0221.6,X*30").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x30);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x30);
         assert!(parse_dbk(s).is_err());
     }
 
     #[test]
     fn test_parse_dbk_invalid_sentence_type() {
         let s = parse_nmea_sentence("$INMTW,17.9,x*20").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x20);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x20);
         assert!(parse_dbk(s).is_err());
     }
 }

--- a/src/sentences/gga.rs
+++ b/src/sentences/gga.rs
@@ -250,7 +250,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::GGA,
             data: "033745.222,5650.82344,N,03548.9778,E,1,07,1.8,101.2,M,14.7,M,,",
-            checksum: 0x57,
+            checksum: Some(0x57),
         })
         .unwrap();
 
@@ -273,7 +273,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::GGA,
             data: "033745.222222222,5650.82344,N,03548.9778,E,1,07,1.8,101.2,M,14.7,M,,",
-            checksum: 0x57,
+            checksum: Some(0x57),
         })
         .unwrap();
 
@@ -296,7 +296,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::GGA,
             data: "033745.000,5650.82344,N,03548.9778,E,1,07,1.8,101.2,M,14.7,M,,",
-            checksum: 0x57,
+            checksum: Some(0x57),
         })
         .unwrap();
 
@@ -318,7 +318,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::GGA,
             data: ",5650.82344,N,03548.9778,E,1,07,1.8,101.2,M,14.7,M,,",
-            checksum: 0x57,
+            checksum: Some(0x57),
         })
         .unwrap();
 

--- a/src/sentences/gga.rs
+++ b/src/sentences/gga.rs
@@ -197,7 +197,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::GGA,
             data: "033745.0,5650.82344,N,03548.9778,E,1,07,1.8,101.2,M,14.7,M,,",
-            checksum: 0x57,
+            checksum: Some(0x57),
         })
         .unwrap();
         assert_eq!(
@@ -213,7 +213,7 @@ mod tests {
         assert_relative_eq!(data.geoid_separation.unwrap(), 14.7);
 
         let s = parse_nmea_sentence("$GPGGA,,,,,,0,,,,,,,,*66").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
         let data = parse_gga(s).unwrap();
         assert_eq!(
             GgaData {
@@ -235,8 +235,9 @@ mod tests {
         let sentence =
             parse_nmea_sentence("$GPGGA,133605.0,5521.75946,N,03731.93769,E,0,00,,,M,,M,,*4F")
                 .unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x4f);
+        let checksum = sentence.calc_checksum();
+        assert_eq!(sentence.checksum.unwrap(), checksum);
+        assert_eq!(sentence.checksum.unwrap(), 0x4f);
         let data = parse_gga(sentence).unwrap();
         assert_eq!(data.fix_type.unwrap(), FixType::Invalid);
     }

--- a/src/sentences/gll.rs
+++ b/src/sentences/gll.rs
@@ -106,8 +106,8 @@ mod tests {
     fn test_parse_gpgll() {
         let parse = |data, checksum| {
             let s = parse_nmea_sentence(data).unwrap();
-            assert_eq!(s.checksum, s.calc_checksum());
-            assert_eq!(s.checksum, checksum);
+            assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+            assert_eq!(s.checksum.unwrap(), checksum);
             s
         };
 

--- a/src/sentences/gns.rs
+++ b/src/sentences/gns.rs
@@ -154,8 +154,8 @@ mod tests {
     #[test]
     fn test_parse_gns() {
         let s = parse_nmea_sentence("$GPGNS,224749.00,3333.4268304,N,11153.3538273,W,D,19,0.6,406.110,-26.294,6.0,0138,S,*46").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x46);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x46);
         let gns_data = parse_gns(s).unwrap();
         assert_eq!(
             gns_data.fix_time,

--- a/src/sentences/gst.rs
+++ b/src/sentences/gst.rs
@@ -91,7 +91,7 @@ mod tests {
 
     fn run_parse_gst(line: &str) -> Result<GstData, Error> {
         let s = parse_nmea_sentence(line).expect("GST sentence initial parse failed");
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
         parse_gst(s)
     }
 

--- a/src/sentences/gsv.rs
+++ b/src/sentences/gsv.rs
@@ -183,7 +183,7 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::GSV,
             data: "2,1,08,01,,083,46,02,17,308,,12,07,344,39,14,22,228,",
-            checksum: 0,
+            checksum: Some(0),
         })
         .unwrap();
         assert_eq!(data.gnss_type, GnssType::Gps);
@@ -235,7 +235,7 @@ mod tests {
             talker_id: "GL",
             message_id: SentenceType::GSV,
             data: "3,3,10,72,40,075,43,87,00,000,",
-            checksum: 0,
+            checksum: Some(0),
         })
         .unwrap();
         assert_eq!(data.gnss_type, GnssType::Glonass);
@@ -247,7 +247,7 @@ mod tests {
             talker_id: "GQ",
             message_id: SentenceType::GSV,
             data: "3,3,10,72,40,075,43,87,00,000,",
-            checksum: 0,
+            checksum: Some(0),
         })
         .unwrap();
         assert_eq!(data.gnss_type, GnssType::Qzss);

--- a/src/sentences/hdt.rs
+++ b/src/sentences/hdt.rs
@@ -72,13 +72,13 @@ mod tests {
             talker_id: "GP",
             message_id: SentenceType::HDT,
             data: "274.07,T",
-            checksum: 0x03,
+            checksum: Some(0x03),
         })
         .unwrap();
         assert_relative_eq!(data.heading.unwrap(), 274.07);
 
         let s = parse_nmea_sentence("$GPHDT,,T*1B").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
 
         let data = parse_hdt(s);
         assert_eq!(data, Ok(HdtData { heading: None }));

--- a/src/sentences/mda.rs
+++ b/src/sentences/mda.rs
@@ -155,8 +155,8 @@ mod tests {
             "$WIMDA,29.7544,I,1.0076,B,35.5,C,,,42.1,,20.6,C,116.4,T,107.7,M,1.2,N,0.6,M*66",
         )
         .unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x66);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x66);
         let mda_data = parse_mda(s).unwrap();
         assert_relative_eq!(29.7544, mda_data.pressure_in_hg.unwrap());
         assert_relative_eq!(1.0076, mda_data.pressure_bar.unwrap());

--- a/src/sentences/mtw.rs
+++ b/src/sentences/mtw.rs
@@ -79,8 +79,8 @@ mod tests {
     #[test]
     fn test_parse_mtw() {
         let s = parse_nmea_sentence("$INMTW,17.9,C*1B").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x1B);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x1B);
         let mtw_data = parse_mtw(s).unwrap();
         assert_eq!(Some(17.9), mtw_data.temperature);
     }
@@ -88,16 +88,16 @@ mod tests {
     #[test]
     fn test_parse_mtw_invalid_unit() {
         let s = parse_nmea_sentence("$INMTW,17.9,x*20").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x20);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x20);
         assert!(parse_mtw(s).is_err());
     }
 
     #[test]
     fn test_parse_mtw_invalid_temp() {
         let s = parse_nmea_sentence("$INMTW,x.9,C*65").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x65);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x65);
         assert!(parse_mtw(s).is_err());
     }
 }

--- a/src/sentences/mwv.rs
+++ b/src/sentences/mwv.rs
@@ -122,8 +122,8 @@ mod tests {
     #[test]
     fn test_parse_mwv() {
         let s = parse_nmea_sentence("$WIMWV,041.1,R,01.0,N,A*16").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x16);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x16);
         let wimwv_data = parse_mwv(s).unwrap();
         assert_relative_eq!(41.1, wimwv_data.wind_direction.unwrap());
         assert_eq!(MwvReference::Relative, wimwv_data.reference.unwrap());

--- a/src/sentences/rmc.rs
+++ b/src/sentences/rmc.rs
@@ -214,8 +214,8 @@ mod tests {
             "$GPRMC,225446.33,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E,A*2B",
         )
         .unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x2b);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x2b);
         let rmc_data = parse_rmc(s).unwrap();
         assert_eq!(
             rmc_data.fix_time,
@@ -249,8 +249,8 @@ mod tests {
             "$GPRMC,225446.33,A,4916.45,N,12311.12,W,000.5,054.7,191194,020.3,E*46",
         )
         .unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x46);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x46);
         let RmcData {
             fix_time,
             status_of_fix,

--- a/src/sentences/rmz.rs
+++ b/src/sentences/rmz.rs
@@ -84,8 +84,8 @@ mod tests {
     #[test]
     fn test_successful_parse() {
         let s = parse_nmea_sentence("$PGRMZ,2282,f,3*21").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x21);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x21);
 
         let data = parse_pgrmz(s).unwrap();
         assert_eq!(data.altitude, 2282);

--- a/src/sentences/ttm.rs
+++ b/src/sentences/ttm.rs
@@ -256,7 +256,7 @@ mod tests {
             talker_id: "RA",
             message_id: SentenceType::TTM,
             data: "00,0.5,187.5,T,12.0,17.6,T,0.0,1.2,N,TGT00,T,,100023.00,A",
-            checksum: 0x4e,
+            checksum: Some(0x4e),
         })
         .unwrap();
         assert_eq!(data.target_number.unwrap(), 0);
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn test_parse_ttm_all_optional() {
         let s = parse_nmea_sentence("$RATTM,,,,,,,,,,,,,,,*72").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
 
         let data = parse_ttm(s);
         assert_eq!(

--- a/src/sentences/vhw.rs
+++ b/src/sentences/vhw.rs
@@ -127,7 +127,7 @@ mod tests {
             message_id: SentenceType::AAM,
             data: "",
             talker_id: "GP",
-            checksum: 0,
+            checksum: Some(0),
         };
         assert_eq!(
             Err(Error::WrongSentenceHeader {
@@ -144,7 +144,7 @@ mod tests {
             message_id: SentenceType::VHW,
             talker_id: "GP",
             data: "100.5,T,105.5,M,10.5,N,19.4,K",
-            checksum: 0x4f,
+            checksum: Some(0x4f),
         };
         let vhw_data = parse_vhw(s).unwrap();
         assert_relative_eq!(vhw_data.heading_true.unwrap(), 100.5);
@@ -153,8 +153,8 @@ mod tests {
         assert_relative_eq!(vhw_data.relative_speed_kmph.unwrap(), 19.4);
 
         let s = parse_nmea_sentence("$GPVHW,100.5,T,105.5,M,10.5,N,19.4,K*4F").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x4F);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x4F);
 
         let vhw_data = parse_vhw(s).unwrap();
         assert_relative_eq!(vhw_data.heading_true.unwrap(), 100.5);
@@ -170,7 +170,7 @@ mod tests {
             message_id: SentenceType::VHW,
             talker_id: "GP",
             data: ",T,,M,,N,,K",
-            checksum: 0,
+            checksum: Some(0),
         };
         assert_eq!(
             parse_vhw(s),
@@ -187,7 +187,7 @@ mod tests {
             message_id: SentenceType::VHW,
             talker_id: "GP",
             data: ",T,,M,10.5,N,20.0,K",
-            checksum: 0,
+            checksum: Some(0),
         };
         assert_eq!(
             parse_vhw(s),
@@ -204,7 +204,7 @@ mod tests {
             message_id: SentenceType::VHW,
             talker_id: "GP",
             data: ",,,,,,,",
-            checksum: 0,
+            checksum: Some(0),
         };
         assert_eq!(
             parse_vhw(s),

--- a/src/sentences/vtg.rs
+++ b/src/sentences/vtg.rs
@@ -105,7 +105,7 @@ mod tests {
 
     fn run_parse_vtg(line: &str) -> Result<VtgData, Error> {
         let s = parse_nmea_sentence(line).expect("VTG sentence initial parse failed");
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
         parse_vtg(s)
     }
 

--- a/src/sentences/wnc.rs
+++ b/src/sentences/wnc.rs
@@ -91,15 +91,15 @@ mod tests {
 
     fn run_parse_wnc(line: &str) -> Result<WncData, Error> {
         let s = parse_nmea_sentence(line).expect("WNC sentence initial parse failed");
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
         parse_wnc(s)
     }
 
     #[test]
     fn test_parse_wnc() {
         let sentence = parse_nmea_sentence("$GPWNC,200.00,N,370.40,K,Dest,Origin*58").unwrap();
-        assert_eq!(sentence.checksum, sentence.calc_checksum());
-        assert_eq!(sentence.checksum, 0x58);
+        assert_eq!(sentence.checksum.unwrap(), sentence.calc_checksum());
+        assert_eq!(sentence.checksum.unwrap(), 0x58);
 
         let data = run_parse_wnc("$GPWNC,200.00,N,370.40,K,Dest,Origin*58").unwrap();
         assert_relative_eq!(data.distance_nautical_miles.unwrap(), 200.00);

--- a/src/sentences/zda.rs
+++ b/src/sentences/zda.rs
@@ -152,8 +152,8 @@ mod tests {
 
     fn assert_zda_sentence(sentence: &str, checksum: u8, expected: ZdaData) {
         let s = parse_nmea_sentence(sentence).unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, checksum);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), checksum);
         let zda_data = parse_zda(s).unwrap();
         assert_eq!(zda_data, expected);
     }
@@ -219,7 +219,7 @@ mod tests {
             message_id: SentenceType::AAM,
             data: "",
             talker_id: "GP",
-            checksum: 0,
+            checksum: Some(0),
         };
         assert_eq!(
             Err(Error::WrongSentenceHeader {
@@ -233,8 +233,8 @@ mod tests {
     #[test]
     fn test_parse_zda_datetime() {
         let s = parse_nmea_sentence("$GPZDA,160012.71,11,03,2004,-1,00*7D").unwrap();
-        assert_eq!(s.checksum, s.calc_checksum());
-        assert_eq!(s.checksum, 0x7d);
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), 0x7d);
         let zda_data = parse_zda(s).unwrap();
         assert_eq!(
             zda_data.utc_date(),

--- a/src/sentences/zfo.rs
+++ b/src/sentences/zfo.rs
@@ -81,7 +81,7 @@ mod tests {
 
     fn run_parse_zfo(line: &str) -> Result<ZfoData, Error> {
         let s = parse_nmea_sentence(line).expect("ZFO sentence initial parse failed");
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
         parse_zfo(s)
     }
 

--- a/src/sentences/ztg.rs
+++ b/src/sentences/ztg.rs
@@ -83,7 +83,7 @@ mod tests {
 
     fn run_parse_ztg(line: &str) -> Result<ZtgData, Error> {
         let s = parse_nmea_sentence(line).expect("ZTG sentence initial parse failed");
-        assert_eq!(s.checksum, s.calc_checksum());
+        assert_eq!(s.checksum.unwrap(), s.calc_checksum());
         parse_ztg(s)
     }
 

--- a/tests/all_supported_messages.rs
+++ b/tests/all_supported_messages.rs
@@ -11,6 +11,8 @@ fn test_all_supported_messages() {
         (SentenceType::ALM, "$GPALM,1,1,15,1159,00,441D,4E,16BE,FD5E,A10C9F,4A2DA4,686E81,58CBE1,0A4,001*77"),
         // APA
         (SentenceType::APA, "$GPAPA,A,A,0.10,R,N,V,V,011,M,DEST,011,M*42"),
+        // APA without checksum:
+        (SentenceType::APA, "$GPAPA,A,A,0.10,R,N,V,V,011,M,DEST,011,M"),
         // BWC
         (SentenceType::BWC, "$GPBWC,220516,5130.02,N,00046.34,W,213.8,T,218.0,M,0004.6,N,EGLM*21"),
         // BWW
@@ -25,6 +27,8 @@ fn test_all_supported_messages() {
         (SentenceType::GSA, "$GPGSA,A,3,23,31,22,16,03,07,,,,,,,1.8,1.1,1.4*3E"),
         // GST
         (SentenceType::GST, "$GPGST,182141.000,15.5,15.3,7.2,21.8,0.9,0.5,0.8*54"),
+        // GST without checksum
+        (SentenceType::GST, "$GPGST,182141.000,15.5,15.3,7.2,21.8,0.9,0.5,0.8"),
         // GSV
         (SentenceType::GSV, "$GPGSV,3,1,12,01,49,196,41,03,71,278,32,06,02,323,27,11,21,196,39*72"),
         // HDT


### PR DESCRIPTION

This PR introduces a breaking change to [NmeaSentence](https://docs.rs/nmea/0.7.0/nmea/struct.NmeaSentence.html)

The alternative approach would be to calculate the checksum based on the already parsed data. 
For that,  `calc_checksum` could be run on a new  container type, similar to the `NmeaSentence` but private and without the checksum field. That would ruin the separation of concerns but could save the backwards-compatibility. 